### PR TITLE
bump biblatex to 0.11.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,3 +73,17 @@ A Bibtex entry is represented as another dictionary, see the example above. It h
 The `parsed_names` entry contains the values of all name-list fields, as parsed by the biblatex crate.
 The crate is pretty good at respecting the different ways in which names can be specified in the
 original Biblatex.
+
+## Changelog
+
+## unreleased
+
+Bump biblatex to [0.11.0](https://github.com/typst/biblatex/releases/tag/v0.11.0). This should eliminate most _wasm `unreachable` instruction executed_ errors caused by parsing non-ideal BibTeX files.
+
+## 0.2.0
+
+Expose parsed names to Typst.
+
+## 0.1.0
+
+Initial release.

--- a/examples/main.typ
+++ b/examples/main.typ
@@ -1,5 +1,5 @@
-#import "@preview/citegeist:0.2.0": load-bibliography
-// #import "@local/citegeist:0.1.1": load-bibliography
+// #import "@preview/citegeist:0.2.0": load-bibliography
+#import "@local/citegeist:0.2.1": load-bibliography
 
 #let bibtex_string = read("custom.bib")
 #let bib = load-bibliography(bibtex_string)

--- a/plugin/citegeist/plugin/Cargo.lock
+++ b/plugin/citegeist/plugin/Cargo.lock
@@ -23,7 +23,7 @@ checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "citegeist"
-version = "0.1.0"
+version = "0.2.1"
 dependencies = [
  "biblatex",
  "serde",

--- a/plugin/citegeist/plugin/Cargo.lock
+++ b/plugin/citegeist/plugin/Cargo.lock
@@ -4,12 +4,12 @@ version = 4
 
 [[package]]
 name = "biblatex"
-version = "0.10.0"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a35a7317fcbdbef94b60d0dd0a658711a936accfce4a631fea4bf8e527eff3c2"
+checksum = "53d0c374feba1b9a59042a7c1cf00ce7c34b977b9134fe7c42b08e5183729f66"
 dependencies = [
- "numerals",
  "paste",
+ "roman-numerals-rs",
  "strum",
  "unicode-normalization",
  "unscanny",
@@ -45,12 +45,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
-name = "numerals"
-version = "0.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e25be21376a772d15f97ae789845340a9651d3c4246ff5ebb6a2b35f9c37bd31"
-
-[[package]]
 name = "paste"
 version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -75,10 +69,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "rustversion"
-version = "1.0.20"
+name = "roman-numerals-rs"
+version = "3.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eded382c5f5f786b989652c49544c4877d9f015cc22e145a5ea8ea66c2921cd2"
+checksum = "c85cd47a33a4510b1424fe796498e174c6a9cf94e606460ef022a19f3e4ff85e"
 
 [[package]]
 name = "serde"
@@ -113,23 +107,22 @@ dependencies = [
 
 [[package]]
 name = "strum"
-version = "0.26.3"
+version = "0.27.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fec0f0aef304996cf250b31b5a10dee7980c85da9d759361292b8bca5a18f06"
+checksum = "af23d6f6c1a224baef9d3f61e287d2761385a5b88fdab4eb4c6f11aeb54c4bcf"
 dependencies = [
  "strum_macros",
 ]
 
 [[package]]
 name = "strum_macros"
-version = "0.26.4"
+version = "0.27.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c6bee85a5a24955dc440386795aa378cd9cf82acd5f764469152d2270e581be"
+checksum = "7695ce3845ea4b33927c055a39dc438a45b059f7c1b3d91d38d10355fb8cbca7"
 dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "rustversion",
  "syn",
 ]
 

--- a/plugin/citegeist/plugin/Cargo.toml
+++ b/plugin/citegeist/plugin/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "citegeist"
-version = "0.1.0"
+version = "0.2.1"
 edition = "2021"
 
 [lib]

--- a/plugin/citegeist/plugin/Cargo.toml
+++ b/plugin/citegeist/plugin/Cargo.toml
@@ -8,7 +8,7 @@ crate-type = ["cdylib"]
 
 [dependencies]
 wasm-minimal-protocol = { path = "../" }
-biblatex = "0.10"
+biblatex = "0.11"
 serde = "1.0.204"
 serde_cbor = "0.10"
 serde_derive = "1.0.204"

--- a/plugin/citegeist/plugin/src/lib.rs
+++ b/plugin/citegeist/plugin/src/lib.rs
@@ -26,10 +26,14 @@ struct MyEntry {
     parsed_names: BTreeMap<String, Vec<BTreeMap<String,String>>>
 }
 
+
 #[wasm_func]
-pub fn get_bib_map(bib_contents_u8: &[u8]) -> Vec<u8> {
-    let bib_contents = str::from_utf8(bib_contents_u8).unwrap();
-    let bibliography = Bibliography::parse(bib_contents).unwrap();
+pub fn get_bib_map(bib_contents_u8: &[u8]) -> Result<Vec<u8>, String> {
+    let bib_contents = str::from_utf8(bib_contents_u8)
+        .map_err(|e| format!("invalid UTF-8 in bibliography: {e}"))?;
+    
+    let bibliography = Bibliography::parse(bib_contents)
+        .map_err(|e| format!("failed to parse bibliography: {e}"))?;
 
     let mut ret: BTreeMap<String, MyEntry> = BTreeMap::new();
     
@@ -37,7 +41,7 @@ pub fn get_bib_map(bib_contents_u8: &[u8]) -> Vec<u8> {
         ret.insert(entry.key.clone(), convert_entry(entry));
     }
 
-    return to_vec(&ret).unwrap();
+    to_vec(&ret).map_err(|e| format!("failed to serialize result: {e}"))
 }
 
 

--- a/tests/basic/test.typ
+++ b/tests/basic/test.typ
@@ -1,0 +1,31 @@
+
+#import "/tests/test-lib.typ": *
+
+// #import "@local/citegeist:0.2.1": *
+
+#let basic-bib = "
+@book{knuth1990,
+  author = {Knuth, Donald E.},
+  maintitle = {Maintitle},
+  mainsubtitle = {Sub},
+  volume = {1},
+  part = {2},
+  year = 1990,
+  publisher = {Addison-Wesley Professional},
+  title  = {The {\TeX} Book},
+}
+
+
+@misc{generalized-2025,
+  author = {Katharina Stein and Nils Hodel and Michael Katz and Jörg Hoffmann and Alexander Koller},
+  title = {Improved Generalized Planning with LLMs through Strategy Refinement and Reflection},
+  year = {2025},
+  howpublished = {Submitted to AAAI}
+}
+
+"
+
+
+Hello World
+
+#let bib = load-bibliography(basic-bib)

--- a/tests/basic/test.typ
+++ b/tests/basic/test.typ
@@ -29,3 +29,7 @@
 Hello World
 
 #let bib = load-bibliography(basic-bib)
+
+#assert("knuth1990" in bib)
+#assert(bib.knuth1990.entry_type == "book")
+#assert(bib.knuth1990.fields.title == "The TeX Book")

--- a/tests/inline-comment/test.typ
+++ b/tests/inline-comment/test.typ
@@ -1,0 +1,17 @@
+
+#import "/tests/test-lib.typ": *
+
+#let basic-bib = "
+@book{knuth1990,
+  author = {Knuth, Donald E.},
+  maintitle = {Maintitle},
+  mainsubtitle = {Sub},
+  volume = {1},
+  part = {2}, % here's an inline comment
+  year = 1990,
+  publisher = {Addison-Wesley Professional},
+  title  = {The {\TeX} Book},
+}
+"
+
+#let bib = load-bibliography(basic-bib)

--- a/tests/inline-comment/test.typ
+++ b/tests/inline-comment/test.typ
@@ -1,4 +1,6 @@
 
+// Tests that citegeist can handle inline comments (as per biblatex 0.11.0).
+
 #import "/tests/test-lib.typ": *
 
 #let basic-bib = "

--- a/tests/test-lib.typ
+++ b/tests/test-lib.typ
@@ -1,0 +1,4 @@
+
+// update this line to control what version is being tested
+#import "@local/citegeist:0.2.1": *
+// #import "@preview/citegeist:0.2.0": *


### PR DESCRIPTION
Thanks to https://github.com/typst/biblatex/pull/80, this update should eliminate most _wasm `unreachable` instruction executed_ errors caused by parsing non-ideal BibTeX files.

I also add a changelog section to the end of README.

Resolves #2

See also [biblatex 0.11.0 changelog](https://github.com/typst/biblatex/releases/tag/v0.11.0).


---

**Edit:** The current code is general enough to handle the new `langid` field.

<img width="200" alt="图片" src="https://github.com/user-attachments/assets/4ac920e6-db2d-45fc-bce7-3a18f3217105" />
