### PR TITLE
Expose literal name metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,16 @@ This will print the bibtex entry for the key `bender-koller-2020-climbing`:
 			(family: "Jurafsky", given: "Dan", prefix: "", suffix: ""),
 			(family: "Chai", given: "Joyce", prefix: "", suffix:"")
 		)
+	),
+	name_metadata: (
+		author: (
+			(verbatim: false, literal: false),
+			(verbatim: false, literal: false)
+		),
+		editor: (
+			(verbatim: false, literal: false),
+			(verbatim: false, literal: false)
+		)
 	)
 )
 ```
@@ -71,6 +81,22 @@ The function `load-bibliography` returns a dictionary with one element per bibli
 A Bibtex entry is represented as another dictionary, see the example above. It has three keys: `entry_type` is the Bibtex entry type (e.g. `inproceedings` or `article`); `entry_key` is the key of the Bibtex entry; and `fields` contains all the fields of the Bibtex entry.
 
 The `parsed_names` entry contains the values of all name-list fields, as parsed by the biblatex crate.
+Each parsed name contains `family`, `given`, `prefix`, and `suffix`.
+
+The optional `name_metadata` entry contains one metadata item per parsed name. Its keys match
+`parsed_names`, and its arrays use the same order as the corresponding parsed-name arrays. For
+example, `name_metadata.author.at(0)` describes `parsed_names.author.at(0)`.
+
+Name metadata retains brace-protection information from the parsed BibTeX chunks:
+
+- `verbatim`: at least one part of the name was protected with braces, such as `John {NASA} Smith`
+- `literal`: all non-whitespace parts of the name were protected, such as `{{Typst Team}}`
+
+These booleans are computed from the chunk structure that the `biblatex` crate produces. In
+particular, extra BibTeX braces become `Chunk::Verbatim`; Citegeist checks the chunks for each
+name item after biblatex has parsed and split the name list. It does not infer literal names from
+the formatted text, spacing, or the presence or absence of `family`/`given` parts.
+
 The crate is pretty good at respecting the different ways in which names can be specified in the
 original Biblatex.
 
@@ -93,6 +119,12 @@ cargo test --manifest-path plugin/citegeist/plugin/Cargo.toml
 
 
 ## Changelog
+
+## Unreleased
+
+- Entries now include parallel `name_metadata` with `verbatim` and `literal` booleans so downstream
+  code can distinguish fully protected/literal names like `{{Typst Team}}` from ordinary personal
+  names while `parsed_names` keeps its existing string-only structure.
 
 ## 0.2.2
 

--- a/plugin/citegeist/plugin/src/lib.rs
+++ b/plugin/citegeist/plugin/src/lib.rs
@@ -1,19 +1,31 @@
-#[cfg(target_arch = "wasm32")]
-use wasm_minimal_protocol::*;
 use biblatex::*;
 use core::str;
 use std::collections::HashMap;
+#[cfg(target_arch = "wasm32")]
+use wasm_minimal_protocol::*;
 
 #[cfg(target_arch = "wasm32")]
 initiate_protocol!();
 
-use serde_derive::{Deserialize, Serialize};
 use serde_cbor::to_vec;
+use serde_derive::{Deserialize, Serialize};
 
 const NAME_FIELDS: &[&str] = &[
-    "afterword", "annotator", "author", "bookauthor", "commentator",
-    "editor", "editora", "editorb", "editorc", "foreword", "holder",
-    "introduction", "shortauthor", "shorteditor", "translator",
+    "afterword",
+    "annotator",
+    "author",
+    "bookauthor",
+    "commentator",
+    "editor",
+    "editora",
+    "editorb",
+    "editorc",
+    "foreword",
+    "holder",
+    "introduction",
+    "shortauthor",
+    "shorteditor",
+    "translator",
 ];
 
 #[derive(Debug, Serialize, Deserialize)]
@@ -22,6 +34,13 @@ struct MyEntry {
     entry_key: String,
     fields: HashMap<String, String>,
     parsed_names: HashMap<String, Vec<HashMap<String, String>>>,
+    name_metadata: HashMap<String, Vec<NameMetadata>>,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+struct NameMetadata {
+    verbatim: bool,
+    literal: bool,
 }
 
 /// Main entry point for the plugin.
@@ -71,11 +90,13 @@ fn convert_entry(entry: &Entry, keep_raw_names: bool, sentence_case_titles: bool
         entry_key: entry.key.clone(),
         fields: HashMap::with_capacity(entry.fields.len()),
         parsed_names: HashMap::new(),
+        name_metadata: HashMap::new(),
     };
 
     for (key, chunks) in &entry.fields {
         if NAME_FIELDS.contains(&key.as_str()) {
             if let Ok(names) = <Vec<Person> as Type>::from_chunks(chunks) {
+                let name_chunks = split_name_chunks(chunks);
                 let parsed: Vec<HashMap<String, String>> = names
                     .into_iter()
                     .map(|p| {
@@ -87,7 +108,17 @@ fn convert_entry(entry: &Entry, keep_raw_names: bool, sentence_case_titles: bool
                         ])
                     })
                     .collect();
+                let metadata = (0..parsed.len())
+                    .map(|index| {
+                        let chunks = name_chunks.get(index).map(Vec::as_slice).unwrap_or(&[]);
+                        NameMetadata {
+                            verbatim: name_is_verbatim(chunks),
+                            literal: name_is_literal(chunks),
+                        }
+                    })
+                    .collect();
                 ret.parsed_names.insert(key.clone(), parsed);
+                ret.name_metadata.insert(key.clone(), metadata);
             }
             if keep_raw_names {
                 ret.fields.insert(key.clone(), chunks.format_verbatim());
@@ -116,4 +147,72 @@ fn convert_entry(entry: &Entry, keep_raw_names: bool, sentence_case_titles: bool
     }
 
     ret
+}
+
+fn split_name_chunks(chunks: ChunksRef<'_>) -> Vec<Chunks> {
+    let mut out = Vec::new();
+    let mut current = Vec::new();
+
+    for chunk in chunks {
+        match &chunk.v {
+            Chunk::Normal(s) => {
+                let mut rest = s.as_str();
+                while let Some(pos) = find_name_separator(rest) {
+                    push_normal_chunk(&mut current, rest[..pos].trim_end());
+                    out.push(std::mem::take(&mut current));
+                    rest = rest[pos + "and".len()..].trim_start();
+                }
+                push_normal_chunk(&mut current, rest);
+            }
+            _ => current.push(chunk.clone()),
+        }
+    }
+
+    out.push(current);
+    out
+}
+
+fn find_name_separator(s: &str) -> Option<usize> {
+    s.match_indices("and").find_map(|(pos, _)| {
+        let before = s[..pos].chars().next_back();
+        let after = s[pos + "and".len()..].chars().next();
+        if before.is_some_and(char::is_whitespace) && after.is_some_and(char::is_whitespace) {
+            Some(pos)
+        } else {
+            None
+        }
+    })
+}
+
+fn push_normal_chunk(chunks: &mut Chunks, s: &str) {
+    if !s.is_empty() {
+        chunks.push(Spanned::detached(Chunk::Normal(s.to_string())));
+    }
+}
+
+fn name_is_verbatim(chunks: ChunksRef<'_>) -> bool {
+    chunks
+        .iter()
+        .any(|chunk| matches!(chunk.v, Chunk::Verbatim(_)))
+}
+
+fn name_is_literal(chunks: ChunksRef<'_>) -> bool {
+    let mut saw_content = false;
+
+    for chunk in chunks {
+        match &chunk.v {
+            Chunk::Verbatim(s) => {
+                if s.chars().any(|c| !c.is_whitespace()) {
+                    saw_content = true;
+                }
+            }
+            Chunk::Normal(s) | Chunk::Math(s) => {
+                if s.chars().any(|c| !c.is_whitespace()) {
+                    return false;
+                }
+            }
+        }
+    }
+
+    saw_content
 }

--- a/plugin/citegeist/plugin/tests/integration.rs
+++ b/plugin/citegeist/plugin/tests/integration.rs
@@ -1,5 +1,5 @@
-use std::collections::HashMap;
 use serde_derive::Deserialize;
+use std::collections::HashMap;
 
 #[derive(Debug, Deserialize)]
 struct MyEntry {
@@ -7,6 +7,13 @@ struct MyEntry {
     entry_key: String,
     fields: HashMap<String, String>,
     parsed_names: HashMap<String, Vec<HashMap<String, String>>>,
+    name_metadata: HashMap<String, Vec<NameMetadata>>,
+}
+
+#[derive(Debug, Deserialize)]
+struct NameMetadata {
+    verbatim: bool,
+    literal: bool,
 }
 
 /// Helper: call get_bib_map with defaults (keep_raw_names=true, sentence_case_titles=true).
@@ -51,6 +58,8 @@ fn test_parse_simple_bib() {
     assert_eq!(authors.len(), 1);
     assert_eq!(authors[0].get("family").unwrap(), "Doe");
     assert_eq!(authors[0].get("given").unwrap(), "John");
+    assert_eq!(authors[0].get("prefix").unwrap(), "");
+    assert_eq!(authors[0].get("suffix").unwrap(), "");
 
     // With keep_raw_names, the raw author string is also in fields
     assert!(entry.fields.contains_key("author"));
@@ -185,7 +194,11 @@ fn test_real_world_entry() {
     let editors = entry.parsed_names.get("editor").unwrap();
     assert_eq!(editors.len(), 2);
 
-    assert!(entry.fields.get("url").unwrap().contains("aclanthology.org"));
+    assert!(entry
+        .fields
+        .get("url")
+        .unwrap()
+        .contains("aclanthology.org"));
 }
 
 #[test]
@@ -264,7 +277,10 @@ fn test_sentence_case_titles_true() {
     let entry = result.get("test").unwrap();
 
     // sentence case: first char uppercase, rest lowercase, braced text preserved
-    assert_eq!(entry.fields.get("title").unwrap(), "Test title with Proper nouns");
+    assert_eq!(
+        entry.fields.get("title").unwrap(),
+        "Test title with Proper nouns"
+    );
 }
 
 #[test]
@@ -280,5 +296,44 @@ fn test_sentence_case_titles_false() {
     let entry = result.get("test").unwrap();
 
     // verbatim: preserved as-is (braces stripped but case unchanged)
-    assert_eq!(entry.fields.get("title").unwrap(), "Test Title With Proper Nouns");
+    assert_eq!(
+        entry.fields.get("title").unwrap(),
+        "Test Title With Proper Nouns"
+    );
+}
+
+#[test]
+fn test_parsed_names_mark_literal_and_verbatim_authors() {
+    let bib = r#"
+@online{protected-author,
+    title = "Protected Author",
+    author = {{Typst Team} and Doe, John and John {NASA} Smith},
+    year = "2024",
+}
+"#;
+    let result = parse_bib(bib);
+    let entry = result.get("protected-author").unwrap();
+    let authors = entry.parsed_names.get("author").unwrap();
+    let metadata = entry.name_metadata.get("author").unwrap();
+
+    assert_eq!(authors.len(), 3);
+    assert_eq!(metadata.len(), 3);
+
+    assert_eq!(authors[0].get("family").unwrap(), "Typst Team");
+    assert_eq!(authors[0].get("given").unwrap(), "");
+    assert_eq!(authors[0].len(), 4);
+    assert!(metadata[0].verbatim);
+    assert!(metadata[0].literal);
+
+    assert_eq!(authors[1].get("family").unwrap(), "Doe");
+    assert_eq!(authors[1].get("given").unwrap(), "John");
+    assert_eq!(authors[1].len(), 4);
+    assert!(!metadata[1].verbatim);
+    assert!(!metadata[1].literal);
+
+    assert_eq!(authors[2].get("family").unwrap(), "Smith");
+    assert_eq!(authors[2].get("given").unwrap(), "John NASA");
+    assert_eq!(authors[2].len(), 4);
+    assert!(metadata[2].verbatim);
+    assert!(!metadata[2].literal);
 }

--- a/tests/name-metadata/test.typ
+++ b/tests/name-metadata/test.typ
@@ -1,0 +1,31 @@
+#import "/tests/test-lib.typ": *
+
+#let bib = load-bibliography("
+@online{protected-author,
+  title = {Protected Author},
+  author = {{Typst Team} and Doe, John and John {NASA} Smith},
+  year = {2024},
+}")
+
+#let authors = bib.protected-author.parsed_names.author
+#let metadata = bib.protected-author.name_metadata.author
+
+#assert.eq(authors.len(), 3)
+#assert.eq(metadata.len(), 3)
+#assert.eq(authors.at(0).family, "Typst Team")
+#assert.eq(authors.at(0).given, "")
+#assert.eq(authors.at(0).keys().len(), 4)
+#assert.eq(metadata.at(0).verbatim, true)
+#assert.eq(metadata.at(0).literal, true)
+
+#assert.eq(authors.at(1).family, "Doe")
+#assert.eq(authors.at(1).given, "John")
+#assert.eq(authors.at(1).keys().len(), 4)
+#assert.eq(metadata.at(1).verbatim, false)
+#assert.eq(metadata.at(1).literal, false)
+
+#assert.eq(authors.at(2).family, "Smith")
+#assert.eq(authors.at(2).given, "John NASA")
+#assert.eq(authors.at(2).keys().len(), 4)
+#assert.eq(metadata.at(2).verbatim, true)
+#assert.eq(metadata.at(2).literal, false)


### PR DESCRIPTION
## Summary

- add a parallel `name_metadata` entry for parsed name-list fields
- expose `verbatim` and `literal` booleans derived from biblatex chunk structure
- keep `parsed_names` string-only and unchanged for compatibility
- document the new metadata semantics and add Rust + Typst regression coverage

## Motivation

Downstream packages need a non-heuristic way to tell when a BibTeX name item was fully brace-protected. For example, `{{Typst Team}}` should be available as a literal/protected name without requiring consumers to guess from `family`/`given` shapes.

This extends the structured names work discussed in #1 while keeping the existing `parsed_names` shape intact. Consumers can look up `name_metadata.author.at(i)` for metadata about `parsed_names.author.at(i)`.

## Semantics

- `verbatim`: true when at least one chunk in that name item is `Chunk::Verbatim`, e.g. `John {NASA} Smith`
- `literal`: true when every non-whitespace chunk in that name item is `Chunk::Verbatim`, e.g. `{{Typst Team}}`

The values come from biblatex chunk parsing, not from the rendered text or from heuristics over `family`/`given`.

## Validation

- `cargo test --manifest-path plugin/citegeist/plugin/Cargo.toml`
- `cargo build --manifest-path plugin/citegeist/plugin/Cargo.toml --target wasm32-unknown-unknown --release`
- `tt run --root .`
