### PR TITLE
Preserve entry order; add on-duplicate handling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+target/
+**/target/

--- a/README.md
+++ b/README.md
@@ -64,6 +64,16 @@ This will print the bibtex entry for the key `bender-koller-2020-climbing`:
 Note that you have to `read` the contents of the Bibtex file yourself, because Typst packages can only read files within the package.
 
 
+## Duplicate keys
+
+By default, a duplicate citation key aborts the whole parse with an error (unchanged behaviour). You can opt into tolerating duplicates:
+
+```
+load-bibliography(bib, on-duplicate: "keep-first")  // drop later duplicates
+load-bibliography(bib, on-duplicate: "keep-last")   // drop earlier duplicates
+load-bibliography(bib, on-duplicate: "error")       // default
+```
+
 ## Details
 
 The function `load-bibliography` returns a dictionary with one element per bibliography entry in your Bibtex file. The key of the dictionary element is the Bibtex key (in the example, `bender-koller-2020-climbing`); the value is a data structure representing a Bibtex entry.
@@ -71,6 +81,8 @@ The function `load-bibliography` returns a dictionary with one element per bibli
 A Bibtex entry is represented as another dictionary, see the example above. It has three keys: `entry_type` is the Bibtex entry type (e.g. `inproceedings` or `article`); `entry_key` is the key of the Bibtex entry; and `fields` contains all the fields of the Bibtex entry.
 
 The `parsed_names` entry contains the values of all name-list fields, as parsed by the biblatex crate.
+
+Entries are returned **in the order they appear in the `.bib` file**.
 The crate is pretty good at respecting the different ways in which names can be specified in the
 original Biblatex.
 
@@ -93,6 +105,12 @@ cargo test --manifest-path plugin/citegeist/plugin/Cargo.toml
 
 
 ## Changelog
+
+## Unreleased
+
+- Entries are now returned in the order they appear in the `.bib` file (previously the order was unspecified, because entries were stored in a `HashMap`).
+- New `on-duplicate` parameter: `"error"` (default, unchanged), `"keep-first"`, or `"keep-last"`, controlling how a duplicate citation key is handled instead of always aborting the parse.
+
 
 ## 0.2.2
 

--- a/lib.typ
+++ b/lib.typ
@@ -1,10 +1,21 @@
 
 
-#let load-bibliography(bibtex-string, keep-raw-names: true, sentence-case-titles: true) = {
+#let load-bibliography(
+  bibtex-string,
+  keep-raw-names: true,
+  sentence-case-titles: true,
+  on-duplicate: "error",
+) = {
   let p = plugin("citegeist.wasm")
   let raw-names-opt = if keep-raw-names { bytes((1,)) } else { bytes((0,)) }
   let sentence-opt = if sentence-case-titles { bytes((1,)) } else { bytes((0,)) }
-  let serialized = p.get_bib_map(bytes(bibtex-string), raw-names-opt, sentence-opt)
+  // on-duplicate: "error" (0, default) / "keep-first" (1) / "keep-last" (2)
+  let dup-opt = bytes((
+    if on-duplicate == "keep-first" { 1 }
+    else if on-duplicate == "keep-last" { 2 }
+    else { 0 },
+  ))
+  let serialized = p.get_bib_map(bytes(bibtex-string), raw-names-opt, sentence-opt, dup-opt)
   let bib-map = cbor(serialized)
 
   bib-map

--- a/plugin/citegeist/plugin/Cargo.lock
+++ b/plugin/citegeist/plugin/Cargo.lock
@@ -26,11 +26,18 @@ name = "citegeist"
 version = "0.2.2"
 dependencies = [
  "biblatex",
+ "indexmap",
  "serde",
  "serde_cbor",
  "serde_derive",
  "wasm-minimal-protocol",
 ]
+
+[[package]]
+name = "equivalent"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
 name = "half"
@@ -39,10 +46,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1b43ede17f21864e81be2fa654110bf1e793774238d86ef8555c37e6519c0403"
 
 [[package]]
+name = "hashbrown"
+version = "0.15.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
+
+[[package]]
 name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
+name = "indexmap"
+version = "2.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "206a8042aec68fa4a62e8d3f7aa4ceb508177d9324faf261e1959e495b7a1921"
+dependencies = [
+ "equivalent",
+ "hashbrown",
+ "serde",
+]
 
 [[package]]
 name = "paste"

--- a/plugin/citegeist/plugin/Cargo.toml
+++ b/plugin/citegeist/plugin/Cargo.toml
@@ -9,6 +9,7 @@ crate-type = ["cdylib", "rlib"]
 [dependencies]
 wasm-minimal-protocol = { path = "../" }
 biblatex = "0.11"
+indexmap = { version = "2", features = ["serde"] }
 serde = { version = "1.0.204", features = ["derive"] }
 serde_cbor = "0.10"
 serde_derive = "1.0.204"
@@ -21,3 +22,6 @@ codegen-units = 1   # Reduce number of codegen units to increase optimizations
 panic = 'abort'     # Abort on panic
 
 [workspace] # so that it is not included in the upper workspace
+
+[dev-dependencies]
+indexmap = "2"

--- a/plugin/citegeist/plugin/src/lib.rs
+++ b/plugin/citegeist/plugin/src/lib.rs
@@ -87,7 +87,8 @@ pub fn get_bib_map(
             .map_err(|e| format!("failed to parse bibliography: {e}"))?
     };
 
-    // IndexMap 保留 `bibliography.iter()` 的源文件顺序（biblatex 内部 entries: Vec<Entry>）。
+    // IndexMap preserves source order from `bibliography.iter()` 
+    // to match biblatex's internal Vec<Entry>.
     let mut ret: IndexMap<String, MyEntry> = IndexMap::with_capacity(bibliography.len());
 
     for entry in bibliography.iter() {

--- a/plugin/citegeist/plugin/src/lib.rs
+++ b/plugin/citegeist/plugin/src/lib.rs
@@ -3,6 +3,7 @@ use wasm_minimal_protocol::*;
 use biblatex::*;
 use core::str;
 use std::collections::HashMap;
+use indexmap::IndexMap;
 
 #[cfg(target_arch = "wasm32")]
 initiate_protocol!();
@@ -20,8 +21,8 @@ const NAME_FIELDS: &[&str] = &[
 struct MyEntry {
     entry_type: String,
     entry_key: String,
-    fields: HashMap<String, String>,
-    parsed_names: HashMap<String, Vec<HashMap<String, String>>>,
+    fields: IndexMap<String, String>,
+    parsed_names: IndexMap<String, Vec<HashMap<String, String>>>,
 }
 
 /// Main entry point for the plugin.
@@ -32,11 +33,17 @@ struct MyEntry {
 ///      0 = omit them (default: 1 if empty)
 ///   - `sentence_case_titles_u8`: single byte; 1 = format titles in sentence case,
 ///      0 = keep titles verbatim (default: 1 if empty)
+///   - `on_duplicate_u8`: single byte controlling duplicate-key handling
+///      (default: 0 if empty):
+///        * 0 = error (the whole parse fails, as before);
+///        * 1 = keep the first entry with a given key, drop later duplicates;
+///        * 2 = keep the last entry with a given key, drop earlier duplicates.
 #[cfg_attr(target_arch = "wasm32", wasm_func)]
 pub fn get_bib_map(
     bib_contents_u8: &[u8],
     keep_raw_names_u8: &[u8],
     sentence_case_titles_u8: &[u8],
+    on_duplicate_u8: &[u8],
 ) -> Result<Vec<u8>, String> {
     let keep_raw_names = match keep_raw_names_u8.first() {
         Some(&b) => b != 0,
@@ -46,14 +53,42 @@ pub fn get_bib_map(
         Some(&b) => b != 0,
         None => true,
     };
+    let on_duplicate = on_duplicate_u8.first().copied().unwrap_or(0);
 
     let bib_contents = str::from_utf8(bib_contents_u8)
         .map_err(|e| format!("invalid UTF-8 in bibliography: {e}"))?;
 
-    let bibliography = Bibliography::parse(bib_contents)
-        .map_err(|e| format!("failed to parse bibliography: {e}"))?;
+    let bibliography = if on_duplicate == 0 {
+        // Default: hard error on a duplicate key (unchanged behaviour).
+        Bibliography::parse(bib_contents)
+            .map_err(|e| format!("failed to parse bibliography: {e}"))?
+    } else {
+        // Tolerant modes: dedup at the raw level (before `from_raw`, which is
+        // where the duplicate-key check lives), then build normally so xdata /
+        // crossref resolution still runs.
+        let mut raw = RawBibliography::parse(bib_contents)
+            .map_err(|e| format!("failed to parse bibliography: {e}"))?;
+        let mut seen = std::collections::HashSet::new();
+        if on_duplicate == 2 {
+            // keep last: walk from the end, keep first-seen-from-the-back, restore order
+            let mut kept: Vec<_> = raw
+                .entries
+                .into_iter()
+                .rev()
+                .filter(|e| seen.insert(e.v.key.v.to_string()))
+                .collect();
+            kept.reverse();
+            raw.entries = kept;
+        } else {
+            // keep first (any non-zero value other than 2)
+            raw.entries.retain(|e| seen.insert(e.v.key.v.to_string()));
+        }
+        Bibliography::from_raw(raw)
+            .map_err(|e| format!("failed to parse bibliography: {e}"))?
+    };
 
-    let mut ret: HashMap<String, MyEntry> = HashMap::with_capacity(bibliography.len());
+    // IndexMap 保留 `bibliography.iter()` 的源文件顺序（biblatex 内部 entries: Vec<Entry>）。
+    let mut ret: IndexMap<String, MyEntry> = IndexMap::with_capacity(bibliography.len());
 
     for entry in bibliography.iter() {
         ret.insert(
@@ -69,8 +104,8 @@ fn convert_entry(entry: &Entry, keep_raw_names: bool, sentence_case_titles: bool
     let mut ret = MyEntry {
         entry_type: entry.entry_type.to_string(),
         entry_key: entry.key.clone(),
-        fields: HashMap::with_capacity(entry.fields.len()),
-        parsed_names: HashMap::new(),
+        fields: IndexMap::with_capacity(entry.fields.len()),
+        parsed_names: IndexMap::new(),
     };
 
     for (key, chunks) in &entry.fields {

--- a/plugin/citegeist/plugin/tests/integration.rs
+++ b/plugin/citegeist/plugin/tests/integration.rs
@@ -11,19 +11,19 @@ struct MyEntry {
 
 /// Helper: call get_bib_map with defaults (keep_raw_names=true, sentence_case_titles=true).
 fn parse_bib(bib: &str) -> HashMap<String, MyEntry> {
-    let result_bytes = citegeist::get_bib_map(bib.as_bytes(), &[1], &[1]).unwrap();
+    let result_bytes = citegeist::get_bib_map(bib.as_bytes(), &[1], &[1], &[]).unwrap();
     serde_cbor::from_slice(&result_bytes).unwrap()
 }
 
 /// Helper: call with keep_raw_names=false, sentence_case_titles=true.
 fn parse_bib_no_raw_names(bib: &str) -> HashMap<String, MyEntry> {
-    let result_bytes = citegeist::get_bib_map(bib.as_bytes(), &[0], &[1]).unwrap();
+    let result_bytes = citegeist::get_bib_map(bib.as_bytes(), &[0], &[1], &[]).unwrap();
     serde_cbor::from_slice(&result_bytes).unwrap()
 }
 
 /// Helper: call with keep_raw_names=true, sentence_case_titles=false.
 fn parse_bib_verbatim_titles(bib: &str) -> HashMap<String, MyEntry> {
-    let result_bytes = citegeist::get_bib_map(bib.as_bytes(), &[1], &[0]).unwrap();
+    let result_bytes = citegeist::get_bib_map(bib.as_bytes(), &[1], &[0], &[]).unwrap();
     serde_cbor::from_slice(&result_bytes).unwrap()
 }
 
@@ -241,7 +241,7 @@ fn test_default_options() {
 }
 "#;
     // Empty options = defaults (keep_raw_names=true, sentence_case_titles=true)
-    let result_bytes = citegeist::get_bib_map(bib.as_bytes(), &[], &[]).unwrap();
+    let result_bytes = citegeist::get_bib_map(bib.as_bytes(), &[], &[], &[]).unwrap();
     let result: HashMap<String, MyEntry> = serde_cbor::from_slice(&result_bytes).unwrap();
     let entry = result.get("test").unwrap();
 
@@ -281,4 +281,58 @@ fn test_sentence_case_titles_false() {
 
     // verbatim: preserved as-is (braces stripped but case unchanged)
     assert_eq!(entry.fields.get("title").unwrap(), "Test Title With Proper Nouns");
+}
+
+// ---- order preservation (entries returned in source order) ----
+
+/// Helper: deserialize into an order-preserving map to assert entry order.
+fn parse_bib_ordered(bib: &str) -> indexmap::IndexMap<String, MyEntry> {
+    let result_bytes = citegeist::get_bib_map(bib.as_bytes(), &[1], &[1], &[]).unwrap();
+    serde_cbor::from_slice(&result_bytes).unwrap()
+}
+
+#[test]
+fn test_entry_order_preserved() {
+    // Mixed entry types and non-alphabetical keys: a HashMap would reorder these.
+    let bib = r#"
+@article{zebra, title = {Z}, author = {A}, year = {2020}}
+@book{alpha,    title = {A}, author = {B}, year = {2021}}
+@inproceedings{mango, title = {M}, author = {C}, year = {2022}}
+@book{beta,     title = {Be}, author = {D}, year = {2023}}
+@misc{xray,     title = {X}, author = {E}, year = {2024}}
+"#;
+    let result = parse_bib_ordered(bib);
+    let order: Vec<&str> = result.keys().map(|s| s.as_str()).collect();
+    assert_eq!(order, vec!["zebra", "alpha", "mango", "beta", "xray"]);
+}
+
+// ---- duplicate-key handling ----
+
+#[test]
+fn test_duplicate_key_errors_by_default() {
+    let bib = "@book{k, title={First}, author={A}, year={2020}}\n\
+               @book{k, title={Second}, author={B}, year={2021}}";
+    // on_duplicate = 0 (empty) -> hard error, unchanged behaviour.
+    assert!(citegeist::get_bib_map(bib.as_bytes(), &[1], &[1], &[]).is_err());
+    assert!(citegeist::get_bib_map(bib.as_bytes(), &[1], &[1], &[0]).is_err());
+}
+
+#[test]
+fn test_duplicate_key_keep_first() {
+    let bib = "@book{k, title={First}, author={A}, year={2020}}\n\
+               @book{k, title={Second}, author={B}, year={2021}}";
+    let bytes = citegeist::get_bib_map(bib.as_bytes(), &[1], &[1], &[1]).unwrap();
+    let result: HashMap<String, MyEntry> = serde_cbor::from_slice(&bytes).unwrap();
+    assert_eq!(result.len(), 1);
+    assert_eq!(result["k"].fields["title"], "First");
+}
+
+#[test]
+fn test_duplicate_key_keep_last() {
+    let bib = "@book{k, title={First}, author={A}, year={2020}}\n\
+               @book{k, title={Second}, author={B}, year={2021}}";
+    let bytes = citegeist::get_bib_map(bib.as_bytes(), &[1], &[1], &[2]).unwrap();
+    let result: HashMap<String, MyEntry> = serde_cbor::from_slice(&bytes).unwrap();
+    assert_eq!(result.len(), 1);
+    assert_eq!(result["k"].fields["title"], "Second");
 }


### PR DESCRIPTION
Preserve entry order and add configurable duplicate handling

**Fixes #7:**
- Replace HashMap with IndexMap to maintain source order in load-bibliography

**Addresses #9:**
- Add on-duplicate parameter (error | keep-first | keep-last)
- Tolerant modes deduplicate at raw level before from_raw, preserving xdata/crossref

**Testing:** 16 tests pass (12 existing + 4 new)