### PR TITLE
Add verbatim field mode

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+target/
+**/target/

--- a/README.md
+++ b/README.md
@@ -64,6 +64,16 @@ This will print the bibtex entry for the key `bender-koller-2020-climbing`:
 Note that you have to `read` the contents of the Bibtex file yourself, because Typst packages can only read files within the package.
 
 
+## Verbatim field values
+
+By default, field values are returned with the biblatex crate's interpretation applied (escapes resolved, braces stripped, titles optionally sentence-cased). If you do your own LaTeX handling and need the untouched source, pass `verbatim: true`:
+
+```
+load-bibliography(bib, verbatim: true)
+```
+
+Every field value is then the exact substring of the `.bib` source (e.g. `\textbackslash`, `\$`, `{NASA}` and `\\` are preserved as written), with no interpretation.
+
 ## Details
 
 The function `load-bibliography` returns a dictionary with one element per bibliography entry in your Bibtex file. The key of the dictionary element is the Bibtex key (in the example, `bender-koller-2020-climbing`); the value is a data structure representing a Bibtex entry.
@@ -93,6 +103,11 @@ cargo test --manifest-path plugin/citegeist/plugin/Cargo.toml
 
 
 ## Changelog
+
+## Unreleased
+
+- New `verbatim` parameter: when `true`, every field value is returned byte-for-byte as written in the source (no LaTeX/escape interpretation, no brace stripping, no sentence casing), for consumers that do their own LaTeX handling.
+
 
 ## 0.2.2
 

--- a/lib.typ
+++ b/lib.typ
@@ -1,10 +1,17 @@
 
 
-#let load-bibliography(bibtex-string, keep-raw-names: true, sentence-case-titles: true) = {
+#let load-bibliography(
+  bibtex-string,
+  keep-raw-names: true,
+  sentence-case-titles: true,
+  verbatim: false,
+) = {
   let p = plugin("citegeist.wasm")
   let raw-names-opt = if keep-raw-names { bytes((1,)) } else { bytes((0,)) }
   let sentence-opt = if sentence-case-titles { bytes((1,)) } else { bytes((0,)) }
-  let serialized = p.get_bib_map(bytes(bibtex-string), raw-names-opt, sentence-opt)
+  // verbatim: return field values byte-for-byte from the source (no interpretation)
+  let verbatim-opt = if verbatim { bytes((1,)) } else { bytes((0,)) }
+  let serialized = p.get_bib_map(bytes(bibtex-string), raw-names-opt, sentence-opt, verbatim-opt)
   let bib-map = cbor(serialized)
 
   bib-map

--- a/plugin/citegeist/plugin/src/lib.rs
+++ b/plugin/citegeist/plugin/src/lib.rs
@@ -32,11 +32,16 @@ struct MyEntry {
 ///      0 = omit them (default: 1 if empty)
 ///   - `sentence_case_titles_u8`: single byte; 1 = format titles in sentence case,
 ///      0 = keep titles verbatim (default: 1 if empty)
+///   - `verbatim_u8`: single byte; 1 = return every field value byte-for-byte
+///      as written in the source (no LaTeX/escape interpretation, no brace
+///      stripping, no sentence casing), 0 = interpret as before
+///      (default: 0 if empty).
 #[cfg_attr(target_arch = "wasm32", wasm_func)]
 pub fn get_bib_map(
     bib_contents_u8: &[u8],
     keep_raw_names_u8: &[u8],
     sentence_case_titles_u8: &[u8],
+    verbatim_u8: &[u8],
 ) -> Result<Vec<u8>, String> {
     let keep_raw_names = match keep_raw_names_u8.first() {
         Some(&b) => b != 0,
@@ -46,6 +51,7 @@ pub fn get_bib_map(
         Some(&b) => b != 0,
         None => true,
     };
+    let verbatim = matches!(verbatim_u8.first(), Some(&b) if b != 0);
 
     let bib_contents = str::from_utf8(bib_contents_u8)
         .map_err(|e| format!("invalid UTF-8 in bibliography: {e}"))?;
@@ -58,14 +64,32 @@ pub fn get_bib_map(
     for entry in bibliography.iter() {
         ret.insert(
             entry.key.clone(),
-            convert_entry(entry, keep_raw_names, sentence_case_titles),
+            convert_entry(entry, keep_raw_names, sentence_case_titles, verbatim, bib_contents),
         );
     }
 
     to_vec(&ret).map_err(|e| format!("failed to serialize result: {e}"))
 }
 
-fn convert_entry(entry: &Entry, keep_raw_names: bool, sentence_case_titles: bool) -> MyEntry {
+/// Byte-for-byte source slice covering a field's chunks (verbatim mode):
+/// from the start of the first chunk's span to the end of the last chunk's span.
+/// Returns the raw `.bib` text, with no escape interpretation or brace stripping.
+fn raw_source(chunks: &Chunks, src: &str) -> String {
+    match (chunks.first(), chunks.last()) {
+        (Some(first), Some(last)) => {
+            src.get(first.span.start..last.span.end).unwrap_or("").to_string()
+        }
+        _ => String::new(),
+    }
+}
+
+fn convert_entry(
+    entry: &Entry,
+    keep_raw_names: bool,
+    sentence_case_titles: bool,
+    verbatim: bool,
+    src: &str,
+) -> MyEntry {
     let mut ret = MyEntry {
         entry_type: entry.entry_type.to_string(),
         entry_key: entry.key.clone(),
@@ -90,16 +114,21 @@ fn convert_entry(entry: &Entry, keep_raw_names: bool, sentence_case_titles: bool
                 ret.parsed_names.insert(key.clone(), parsed);
             }
             if keep_raw_names {
-                ret.fields.insert(key.clone(), chunks.format_verbatim());
+                let v = if verbatim { raw_source(chunks, src) } else { chunks.format_verbatim() };
+                ret.fields.insert(key.clone(), v);
             }
         } else if key == "title" {
-            if sentence_case_titles {
-                ret.fields.insert(key.clone(), chunks.format_sentence());
+            let v = if verbatim {
+                raw_source(chunks, src)
+            } else if sentence_case_titles {
+                chunks.format_sentence()
             } else {
-                ret.fields.insert(key.clone(), chunks.format_verbatim());
-            }
+                chunks.format_verbatim()
+            };
+            ret.fields.insert(key.clone(), v);
         } else {
-            ret.fields.insert(key.clone(), chunks.format_verbatim());
+            let v = if verbatim { raw_source(chunks, src) } else { chunks.format_verbatim() };
+            ret.fields.insert(key.clone(), v);
         }
     }
 

--- a/plugin/citegeist/plugin/tests/integration.rs
+++ b/plugin/citegeist/plugin/tests/integration.rs
@@ -11,19 +11,19 @@ struct MyEntry {
 
 /// Helper: call get_bib_map with defaults (keep_raw_names=true, sentence_case_titles=true).
 fn parse_bib(bib: &str) -> HashMap<String, MyEntry> {
-    let result_bytes = citegeist::get_bib_map(bib.as_bytes(), &[1], &[1]).unwrap();
+    let result_bytes = citegeist::get_bib_map(bib.as_bytes(), &[1], &[1], &[]).unwrap();
     serde_cbor::from_slice(&result_bytes).unwrap()
 }
 
 /// Helper: call with keep_raw_names=false, sentence_case_titles=true.
 fn parse_bib_no_raw_names(bib: &str) -> HashMap<String, MyEntry> {
-    let result_bytes = citegeist::get_bib_map(bib.as_bytes(), &[0], &[1]).unwrap();
+    let result_bytes = citegeist::get_bib_map(bib.as_bytes(), &[0], &[1], &[]).unwrap();
     serde_cbor::from_slice(&result_bytes).unwrap()
 }
 
 /// Helper: call with keep_raw_names=true, sentence_case_titles=false.
 fn parse_bib_verbatim_titles(bib: &str) -> HashMap<String, MyEntry> {
-    let result_bytes = citegeist::get_bib_map(bib.as_bytes(), &[1], &[0]).unwrap();
+    let result_bytes = citegeist::get_bib_map(bib.as_bytes(), &[1], &[0], &[]).unwrap();
     serde_cbor::from_slice(&result_bytes).unwrap()
 }
 
@@ -241,7 +241,7 @@ fn test_default_options() {
 }
 "#;
     // Empty options = defaults (keep_raw_names=true, sentence_case_titles=true)
-    let result_bytes = citegeist::get_bib_map(bib.as_bytes(), &[], &[]).unwrap();
+    let result_bytes = citegeist::get_bib_map(bib.as_bytes(), &[], &[], &[]).unwrap();
     let result: HashMap<String, MyEntry> = serde_cbor::from_slice(&result_bytes).unwrap();
     let entry = result.get("test").unwrap();
 
@@ -281,4 +281,24 @@ fn test_sentence_case_titles_false() {
 
     // verbatim: preserved as-is (braces stripped but case unchanged)
     assert_eq!(entry.fields.get("title").unwrap(), "Test Title With Proper Nouns");
+}
+
+// ---- verbatim field mode ----
+
+#[test]
+fn test_verbatim_field_mode() {
+    // \textbackslash / \$ / braces / \\ must come back byte-for-byte under verbatim.
+    let bib = r#"@book{k, title = {C\textbackslash D and 5\$ x and {NASA} and A\\B}, author = {Smith, J}, year = {2020}}"#;
+    let bytes = citegeist::get_bib_map(bib.as_bytes(), &[1], &[1], &[1]).unwrap();
+    let result: HashMap<String, MyEntry> = serde_cbor::from_slice(&bytes).unwrap();
+    let title = &result["k"].fields["title"];
+    assert_eq!(title, r#"C\textbackslash D and 5\$ x and {NASA} and A\\B"#);
+}
+
+#[test]
+fn test_verbatim_off_interprets_as_before() {
+    let bib = r#"@book{k, title = {a\textbackslash b}, author = {Smith, J}, year = {2020}}"#;
+    let bytes = citegeist::get_bib_map(bib.as_bytes(), &[1], &[1], &[0]).unwrap();
+    let result: HashMap<String, MyEntry> = serde_cbor::from_slice(&bytes).unwrap();
+    assert_ne!(result["k"].fields["title"], r#"a\textbackslash b"#);
 }


### PR DESCRIPTION
Fixes #8.

## What

A new `verbatim` parameter on `load-bibliography`. When set, every field value is returned **byte-for-byte as written in the `.bib` source** — no LaTeX/escape interpretation, no brace stripping, no sentence casing:

```typ
load-bibliography(bib, verbatim: true)
```

For example, with `title = {C\textbackslash D and 5\$ x and {NASA} and A\\B}`:

| mode | returned title |
|---|---|
| default | `C extbackslash d and 5$ x and NASA and a\b` |
| `verbatim: true` | `C\textbackslash D and 5\$ x and {NASA} and A\\B` |

## Why

citegeist is the right tool for consumers that don't use CSL and do their own LaTeX → output conversion (in my case, [omni-gb7714](https://github.com/typst-omni-gb7714/omni-gb7714), a GB/T 7714 bibliography implementation). The trouble is that the returned field strings have already been through a partly lossy interpretation, so distinct inputs collapse and can't be recovered: `\$` and a math `$` become the same, `\textbackslash` is mangled to `extbackslash`, `\\` collapses to `\`, braces are dropped, etc. To work around this I currently have to shadow the parser with a private-use-area sentinel layer before parsing and restore it afterwards. A verbatim mode removes the need for all of that — give me the source, I'll interpret it myself.

## How

The biblatex crate keeps a source span on every chunk (`Chunks = Vec<Spanned<Chunk>>`). Verbatim mode just slices the original input over each field's chunk span (`first.span.start .. last.span.end`), so the value is the untouched source substring. No new dependency.

## Notes

- Backward compatible: the parameter defaults to `false`, so existing behaviour is unchanged. (`verbatim_u8` is empty / `0` → the old interpreted path.)
- **Orthogonal to #6.** This only touches field-value production and adds a parameter; it does not touch `parsed_names`, `name_metadata`, or the name-list code. #6 and this PR change disjoint lines and merge cleanly.
- I also have a separate PR (entry order + `on-duplicate` handling). Both PRs add one parameter to `get_bib_map`; whichever lands first, the other just needs the parameters lined up (4th + 5th) — a trivial rebase.
- 14 tests pass (12 existing + 2 new covering verbatim on/off).
